### PR TITLE
Ports audio_common package to ros2.

### DIFF
--- a/audio_common/CMakeLists.txt
+++ b/audio_common/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(audio_common)
-find_package(catkin REQUIRED)
-catkin_metapackage()
+
+find_package(ament_cmake REQUIRED)
+
+ament_package()

--- a/audio_common/package.xml
+++ b/audio_common/package.xml
@@ -1,4 +1,8 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
    <name>audio_common</name>
    <version>0.3.15</version>
    <description>
@@ -12,14 +16,14 @@
    <url type="repository">https://github.com/ros-drivers/audio_common</url>
    <url type="bugtracker">https://github.com/ros-drivers/audio_common/issues</url>
 
-   <buildtool_depend>catkin</buildtool_depend>
+   <buildtool_depend>ament_cmake</buildtool_depend>
 
-   <run_depend>audio_capture</run_depend>
-   <run_depend>audio_common_msgs</run_depend>
-   <run_depend>audio_play</run_depend>
-   <run_depend>sound_play</run_depend>
+   <exec_depend>audio_capture</exec_depend>
+   <exec_depend>audio_common_msgs</exec_depend>
+   <exec_depend>audio_play</exec_depend>
+   <exec_depend>sound_play</exec_depend>
 
    <export>
-      <metapackage/>
+      <build_type>ament_cmake</build_type>
    </export>
 </package>


### PR DESCRIPTION
Exactly as the tittle states. This PR should be merged after the packages audio_capture, audio_common_msgs, audio_play and sound_play are ported and merged.

- [x] audio_common_msgs #1 
- [x] audio_capture #2 
- [x] audio_play #3 
- [x] sound_play #5 

Signed-off-by: Voldivh <eloyabmfcv@gmail.com>